### PR TITLE
Rename TokenHashingService for better scope representation

### DIFF
--- a/src/main/java/info/mackiewicz/bankapp/security/service/PasswordResetTokenService.java
+++ b/src/main/java/info/mackiewicz/bankapp/security/service/PasswordResetTokenService.java
@@ -27,7 +27,7 @@ public class PasswordResetTokenService {
     private static final int DEFAULT_CLEANUP_DAYS = 30;
 
     private final PasswordResetTokenRepository tokenRepository;
-    private final TokenHashingService tokenHashingService;
+    private final TokenOperationsService tokenOperationsService;
 
     /**
      * Creates a new password reset token for the given user
@@ -47,8 +47,8 @@ public class PasswordResetTokenService {
         }
 
         log.debug("Generating new token and hash for user: {}", userEmail);
-        String plainToken = tokenHashingService.generateToken();
-        String tokenHash = tokenHashingService.hashToken(plainToken);
+        String plainToken = tokenOperationsService.generateToken();
+        String tokenHash = tokenOperationsService.hashToken(plainToken);
 
         saveNewToken(userEmail, fullName, tokenHash);
         log.debug("Successfully created password reset token for user: {}", userEmail);
@@ -73,7 +73,7 @@ public class PasswordResetTokenService {
      */
     public PasswordResetToken getValidatedToken(String token) {
         log.debug("Starting token validation process");
-        String tokenHash = tokenHashingService.hashToken(token);
+        String tokenHash = tokenOperationsService.hashToken(token);
 
         PasswordResetToken foundToken = findTokenByHash(tokenHash);
 
@@ -131,7 +131,7 @@ public class PasswordResetTokenService {
 
     public boolean isTokenPresent(String token) {
         log.debug("Checking if token exists in database");
-        String tokenHash = tokenHashingService.hashToken(token);
+        String tokenHash = tokenOperationsService.hashToken(token);
         boolean exists = tokenRepository.findByTokenHash(tokenHash).isPresent();
         log.debug("Token existence check result: {}", exists);
         return exists;

--- a/src/main/java/info/mackiewicz/bankapp/security/service/TokenOperationsService.java
+++ b/src/main/java/info/mackiewicz/bankapp/security/service/TokenOperationsService.java
@@ -1,26 +1,27 @@
 package info.mackiewicz.bankapp.security.service;
 
-import java.security.SecureRandom;
-import java.util.Base64;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
 
 import org.springframework.stereotype.Service;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Service for secure token generation and hashing using SHA-256
+ * Service for secure token generation, validation and hashing using SHA-256
  */
 @Service
 @Slf4j
-public class TokenHashingService {
+public class TokenOperationsService {
 
     private static final String HASH_ALGORITHM = "SHA-256";
     private static final int TOKEN_LENGTH = 32;
     private final SecureRandom secureRandom;
 
-    public TokenHashingService() {
+    public TokenOperationsService() {
         this.secureRandom = new SecureRandom();
     }
 

--- a/src/test/java/info/mackiewicz/bankapp/integration/PasswordResetTokenIntegrationTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/integration/PasswordResetTokenIntegrationTest.java
@@ -26,7 +26,7 @@ import info.mackiewicz.bankapp.security.model.PasswordResetToken;
 import info.mackiewicz.bankapp.security.repository.PasswordResetTokenRepository;
 import info.mackiewicz.bankapp.security.service.PasswordResetService;
 import info.mackiewicz.bankapp.security.service.PasswordResetTokenService;
-import info.mackiewicz.bankapp.security.service.TokenHashingService;
+import info.mackiewicz.bankapp.security.service.TokenOperationsService;
 import info.mackiewicz.bankapp.testutils.TestUserBuilder;
 import info.mackiewicz.bankapp.user.model.User;
 import info.mackiewicz.bankapp.user.repository.UserRepository;
@@ -50,7 +50,7 @@ public class PasswordResetTokenIntegrationTest {
     private PasswordEncoder passwordEncoder;
     
     @Autowired
-    private TokenHashingService tokenHashingService;
+    private TokenOperationsService tokenHashingService;
     
     @MockitoSpyBean
     private PasswordResetTokenService passwordResetTokenService;

--- a/src/test/java/info/mackiewicz/bankapp/security/service/PasswordResetTokenServiceTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/security/service/PasswordResetTokenServiceTest.java
@@ -1,6 +1,10 @@
 package info.mackiewicz.bankapp.security.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,7 +36,7 @@ class PasswordResetTokenServiceTest {
     private PasswordResetTokenRepository tokenRepository;
     
     @Mock
-    private TokenHashingService tokenHashingService;
+    private TokenOperationsService tokenHashingService;
 
     private PasswordResetTokenService tokenService;
 

--- a/src/test/java/info/mackiewicz/bankapp/security/service/TokenOperationsServiceTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/security/service/TokenOperationsServiceTest.java
@@ -1,22 +1,25 @@
 package info.mackiewicz.bankapp.security.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+class TokenOperationsServiceTest {
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Base64;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class TokenHashingServiceTest {
-
-    private TokenHashingService tokenHashingService;
+    private TokenOperationsService tokenHashingService;
 
     @BeforeEach
     void setUp() {
-        tokenHashingService = new TokenHashingService();
+        tokenHashingService = new TokenOperationsService();
     }
 
     @Test


### PR DESCRIPTION
Renames TokenHashingService to TokenOperationsService to better reflect its full range of responsibilities including token generation, validation, and hashing operations.

Updates all related service references and test files to maintain consistency.