### PR TITLE
Add validation for restricted transaction deletion

### DIFF
--- a/src/main/java/info/mackiewicz/bankapp/core/transaction/exception/TransactionDeletionForbiddenException.java
+++ b/src/main/java/info/mackiewicz/bankapp/core/transaction/exception/TransactionDeletionForbiddenException.java
@@ -1,0 +1,25 @@
+package info.mackiewicz.bankapp.core.transaction.exception;
+
+import info.mackiewicz.bankapp.system.error.handling.core.error.ErrorCode;
+
+/**
+ * Exception thrown when an attempt is made to delete a transaction that is not allowed to be deleted.
+ * <p>
+ * This exception is typically used in scenarios where specific business rules or transaction states
+ * forbid the deletion of certain transactions, such as transactions that are already processed
+ * or currently in process.
+ * <p>
+ * The associated error code for this exception is {@code ErrorCode.TRANSACTION_NOT_DELETABLE}.
+ */
+public class TransactionDeletionForbiddenException extends TransactionBaseException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.TRANSACTION_NOT_DELETABLE;
+
+    public TransactionDeletionForbiddenException(String message) {
+        super(message, ERROR_CODE);
+    }
+
+    public TransactionDeletionForbiddenException(String message, Throwable cause) {
+        super(message, cause, ERROR_CODE);
+    }
+}

--- a/src/main/java/info/mackiewicz/bankapp/core/transaction/service/TransactionCommandService.java
+++ b/src/main/java/info/mackiewicz/bankapp/core/transaction/service/TransactionCommandService.java
@@ -1,8 +1,10 @@
 package info.mackiewicz.bankapp.core.transaction.service;
 
+import info.mackiewicz.bankapp.core.transaction.exception.TransactionDeletionForbiddenException;
 import info.mackiewicz.bankapp.core.transaction.exception.TransactionNotFoundException;
 import info.mackiewicz.bankapp.core.transaction.exception.TransactionValidationException;
 import info.mackiewicz.bankapp.core.transaction.model.Transaction;
+import info.mackiewicz.bankapp.core.transaction.model.TransactionStatus;
 import info.mackiewicz.bankapp.core.transaction.repository.TransactionRepository;
 import info.mackiewicz.bankapp.core.transaction.validation.TransactionValidator;
 import lombok.RequiredArgsConstructor;
@@ -27,16 +29,17 @@ class TransactionCommandService {
      * If the transaction is of type TRANSFER_OWN, it will be processed immediately.
      *
      * @param transaction the transaction to create
+     *
      * @return the saved transaction with generated ID
      * @throws TransactionValidationException if the transaction fails validation
      */
     @Transactional
     public Transaction registerTransaction(Transaction transaction) {
         log.debug("Creating new transaction: {}", transaction);
-        
+
         // Validate before saving
         validator.validate(transaction);
-        
+
         // Save to repository
         Transaction savedTransaction = repository.save(transaction);
         log.debug("Transaction saved with ID: {}", savedTransaction.getId());
@@ -44,16 +47,33 @@ class TransactionCommandService {
         return savedTransaction;
     }
 
+
     /**
-     * Deletes a transaction from the system by its ID.
+     * Deletes a transaction by its ID.
+     *
+     * The transaction can only be deleted if it has the status `NEW`.
+     * If the status is not `NEW`, a {@code TransactionDeletionForbiddenException} will be thrown.
+     * If the transaction does not exist, a {@code TransactionNotFoundException} will be thrown.
      *
      * @param id the ID of the transaction to delete
-     * @throws TransactionNotFoundException if no transaction is found with the given ID
+     * @throws TransactionNotFoundException if no transaction is found with the specified ID
+     * @throws TransactionDeletionForbiddenException if the transaction status does not allow deletion
      */
-    public void deleteTransactionById(int id) {
+    public void deleteTransactionById(int id) throws TransactionNotFoundException, TransactionDeletionForbiddenException {
         log.info("Attempting to delete transaction: {}", id);
         Transaction transaction = queryService.getTransactionById(id);
-        repository.delete(transaction);
-        log.info("Transaction {} deleted successfully", id);
+        if (isTransactionDeletable(transaction)) {
+            repository.delete(transaction);
+            log.info("Transaction {} deleted successfully", id);
+        } else {
+            String message = String.format("Transaction not deletable. Only transactions with status NEW can be deleted. " +
+                    "Transaction Status: %s", transaction.getStatus());
+            throw new TransactionDeletionForbiddenException(message);
+        }
+    }
+
+    private boolean isTransactionDeletable(Transaction transaction) {
+        //transactions without `status` are invalid so it can (and probably should) be deleted.
+        return transaction.getStatus() == null || TransactionStatus.NEW.equals(transaction.getStatus());
     }
 }

--- a/src/main/java/info/mackiewicz/bankapp/system/error/handling/core/error/ErrorCode.java
+++ b/src/main/java/info/mackiewicz/bankapp/system/error/handling/core/error/ErrorCode.java
@@ -2,9 +2,8 @@ package info.mackiewicz.bankapp.system.error.handling.core.error;
 
 import info.mackiewicz.bankapp.system.error.handling.core.ApiExceptionHandler;
 import info.mackiewicz.bankapp.system.error.handling.core.BankAppBaseException;
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 /**
  * Defines all possible error codes in the BankApp application along with their corresponding
@@ -79,6 +78,7 @@ public enum ErrorCode {
     NO_TRANSACTIONS_FOR_ACCOUNT(HttpStatus.NOT_FOUND, "No transactions found for this account."),
     TRANSACTION_ACCOUNT_CONFLICT(HttpStatus.BAD_REQUEST, "Source and destination accounts cannot be the same."),
     INVALID_IBAN(HttpStatus.BAD_REQUEST, "Invalid IBAN. Please check your input and try again."),
+    TRANSACTION_NOT_DELETABLE(HttpStatus.FORBIDDEN, "You cannot delete transaction that is already processed or in process."),
     // Other errors
     UNSUPPORTED_EXPORTER(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Unsupported export format. Please choose a different one.");
 


### PR DESCRIPTION
### Summary

This pull request introduces proper validation to handle restricted transaction deletions based on transaction status.

### Details

- Added `TransactionDeletionForbiddenException` to handle invalid deletion attempts.
- Enhanced `ErrorCode` with `TRANSACTION_NOT_DELETABLE`.
- Updated `TransactionCommandService` to enforce deletion rules based on transaction statuses such as `NEW`, `DONE`, and `PENDING`.
- Created and extended unit tests to validate the behavior across different statuses.

### related issues
closes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users are now prevented from deleting transactions that have already been processed or are currently in process. Attempting to do so will result in a clear error message indicating the action is forbidden.

- **Bug Fixes**
  - Improved error handling and messaging when attempting to delete non-deletable transactions.

- **Tests**
  - Added comprehensive tests to ensure transaction deletion is only allowed for eligible statuses and that forbidden deletions are properly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->