### PR TITLE
Update API paths for registration and password reset to `/api/public` namespace

### DIFF
--- a/src/main/java/info/mackiewicz/bankapp/shared/config/SecurityConfig.java
+++ b/src/main/java/info/mackiewicz/bankapp/shared/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package info.mackiewicz.bankapp.shared.config;
 
-import info.mackiewicz.bankapp.core.user.service.AdminUserService;
 import info.mackiewicz.bankapp.shared.service.CustomUserDetailsService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -26,12 +25,9 @@ import org.springframework.security.web.session.HttpSessionEventPublisher;
 public class SecurityConfig {
 
     private final CustomUserDetailsService userDetailsService;
-    private final AdminUserService adminUserService;
 
-    public SecurityConfig(CustomUserDetailsService userDetailsService,
-            AdminUserService adminUserService) {
+    public SecurityConfig(CustomUserDetailsService userDetailsService) {
         this.userDetailsService = userDetailsService;
-        this.adminUserService = adminUserService;
         log.info("Initializing SecurityConfig...");
     }
 
@@ -79,8 +75,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/password/**").permitAll()
-                        .requestMatchers("/api/registration/**").permitAll()
+                        .requestMatchers("/api/public/**").permitAll()
                         .anyRequest().authenticated())
                 .httpBasic(basic -> basic
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))

--- a/src/main/java/info/mackiewicz/bankapp/system/recovery/password/controller/PasswordResetController.java
+++ b/src/main/java/info/mackiewicz/bankapp/system/recovery/password/controller/PasswordResetController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * - Completing the password reset by submitting a token and new password.
  */
 @Tag(name = "Password Reset")
-@RequestMapping("/api/password")
+@RequestMapping("/api/public/password")
 public interface PasswordResetController {
 
     @Operation(

--- a/src/main/java/info/mackiewicz/bankapp/system/registration/controller/RegistrationController.java
+++ b/src/main/java/info/mackiewicz/bankapp/system/registration/controller/RegistrationController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping("/api/registration")
+@RequestMapping("/api/public/registration")
 @Tag(name = "Registration", description = "API for user registration")
 public interface RegistrationController {
 

--- a/src/test/java/info/mackiewicz/bankapp/integration/registration/RegistrationControllerIntegrationTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/integration/registration/RegistrationControllerIntegrationTest.java
@@ -38,8 +38,8 @@ class RegistrationControllerIntegrationTest {
     private static final String TEST_EMAIL = "jan.kowalski@example.com";
     private static final String TEST_FIRSTNAME = "Jan";
     private static final String TEST_LASTNAME = "Kowalski";
-    private static final String REGISTRATION_ENDPOINT = "/api/registration/regular";
-    private static final String DEMO_REGISTRATION_ENDPOINT = "/api/registration/demo";
+    private static final String REGISTRATION_ENDPOINT = "/api/public/registration/regular";
+    private static final String DEMO_REGISTRATION_ENDPOINT = "/api/public/registration/demo";
     private static final String DATE_OF_BIRTH_FIELD = "dateOfBirth";
     private static final String FIRSTNAME_FIELD = "firstname";
     private static final String PESEL_FIELD = "pesel";

--- a/src/test/java/info/mackiewicz/bankapp/integration/registration/RegistrationEndToEndTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/integration/registration/RegistrationEndToEndTest.java
@@ -53,7 +53,7 @@ class RegistrationEndToEndTest {
     private static final String TEST_FIRSTNAME = "Jan";
     private static final String TEST_LASTNAME = "Kowalski";
     private static final String TEST_FULLNAME = "Jan Kowalski";
-    private static final String REGISTRATION_ENDPOINT = "/api/registration/regular";
+    private static final String REGISTRATION_ENDPOINT = "/api/public/registration/regular";
 
     @Value("${bankapp.registration.WelcomeBonusAmount:1000}")
     private BigDecimal welcomeBonusAmount;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the URLs for password reset and registration APIs. Endpoints now start with /api/public/ instead of /api/ for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->