### PR TITLE
feat(security): validate transaction title format and add related tests

### DIFF
--- a/src/main/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidator.java
+++ b/src/main/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidator.java
@@ -7,6 +7,7 @@ import info.mackiewicz.bankapp.core.transaction.model.Transaction;
 import info.mackiewicz.bankapp.core.transaction.model.TransactionType;
 import info.mackiewicz.bankapp.core.transaction.model.TransactionTypeCategory;
 import info.mackiewicz.bankapp.core.user.model.User;
+import info.mackiewicz.bankapp.shared.validation.ValidationConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +28,13 @@ public class DefaultTransactionValidator implements TransactionValidator {
         validateAccounts(transaction);
         validateSufficientFunds(transaction);
         validateSameOwnerForOwnTransfer(transaction);
+        validateTitle(transaction);
+    }
+
+    private void validateTitle(Transaction transaction) {
+        if (!transaction.getTitle().matches(ValidationConstants.TRANSFER_TITLE_PATTERN)) {
+            throw new TransactionValidationException("Transaction title contains invalid characters");
+        }
     }
 
     private void validateSufficientFunds(Transaction transaction) {

--- a/src/main/java/info/mackiewicz/bankapp/shared/validation/ValidationConstants.java
+++ b/src/main/java/info/mackiewicz/bankapp/shared/validation/ValidationConstants.java
@@ -34,6 +34,13 @@ import lombok.experimental.UtilityClass;
 public final class ValidationConstants {
 
     /**
+     * A regular expression pattern used to validate the format of a transfer title.
+     * This pattern ensures the title consists of letters, digits, and specific
+     * allowable special characters including .,/?@!#&()- as well as spaces.
+     */
+    public static final String TRANSFER_TITLE_PATTERN = "^[\\p{L}0-9.,/?@!%#&()\\-\\s]+$";
+
+    /**
      * Regular expression pattern for validating email addresses.<br>
      * This pattern allows:<br>
      * - Alphanumeric characters (a-z, A-Z, 0-9)<br>

--- a/src/main/java/info/mackiewicz/bankapp/shared/validation/ValidationConstants.java
+++ b/src/main/java/info/mackiewicz/bankapp/shared/validation/ValidationConstants.java
@@ -36,7 +36,7 @@ public final class ValidationConstants {
     /**
      * A regular expression pattern used to validate the format of a transfer title.
      * This pattern ensures the title consists of letters, digits, and specific
-     * allowable special characters including .,/?@!#&()- as well as spaces.
+     * allowable special characters including .,/?@!%#&()- as well as spaces.
      */
     public static final String TRANSFER_TITLE_PATTERN = "^[\\p{L}0-9.,/?@!%#&()\\-\\s]+$";
 

--- a/src/main/java/info/mackiewicz/bankapp/system/banking/operations/controller/dto/TransactionRequest.java
+++ b/src/main/java/info/mackiewicz/bankapp/system/banking/operations/controller/dto/TransactionRequest.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import info.mackiewicz.bankapp.core.transaction.model.Transaction;
 import info.mackiewicz.bankapp.shared.annotations.ValidIban;
+import info.mackiewicz.bankapp.shared.validation.ValidationConstants;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
@@ -48,6 +50,7 @@ public abstract class TransactionRequest {
     @NotNull(message = "Amount cannot be null")
     private BigDecimal amount;
 
+    @Pattern(regexp = ValidationConstants.TRANSFER_TITLE_PATTERN, message = "Title contains invalid characters")
     @Schema(description = "Title of the transaction")
     @NotBlank(message = "Title cannot be blank")
     private String title;

--- a/src/test/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidatorTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/core/transaction/validation/DefaultTransactionValidatorTest.java
@@ -2,6 +2,7 @@ package info.mackiewicz.bankapp.core.transaction.validation;
 
 import info.mackiewicz.bankapp.core.account.model.Account;
 import info.mackiewicz.bankapp.core.account.model.TestAccountBuilder;
+import info.mackiewicz.bankapp.core.transaction.exception.InsufficientFundsException;
 import info.mackiewicz.bankapp.core.transaction.exception.TransactionAccountConflictException;
 import info.mackiewicz.bankapp.core.transaction.exception.TransactionValidationException;
 import info.mackiewicz.bankapp.core.transaction.model.Transaction;
@@ -37,6 +38,7 @@ class DefaultTransactionValidatorTest {
         transaction.setAmount(BigDecimal.TEN);
         transaction.setSourceAccount(sourceAccount);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -48,6 +50,7 @@ class DefaultTransactionValidatorTest {
         transaction.setType(TransactionType.DEPOSIT);
         transaction.setAmount(BigDecimal.TEN);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -59,6 +62,7 @@ class DefaultTransactionValidatorTest {
         transaction.setType(TransactionType.WITHDRAWAL);
         transaction.setAmount(BigDecimal.TEN);
         transaction.setSourceAccount(sourceAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -105,6 +109,48 @@ class DefaultTransactionValidatorTest {
     }
 
     @Test
+    void validate_WithInsufficientFunds_ShouldThrowException() {
+        // Given
+        transaction.setType(TransactionType.WITHDRAWAL);
+        transaction.setAmount(BigDecimal.valueOf(10000));
+        transaction.setSourceAccount(sourceAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
+
+        // When & Then
+        assertThrows(InsufficientFundsException.class,
+                () -> validator.validate(transaction),
+                "Insufficient funds for transaction");
+    }
+
+    @Test
+    void validate_WithInvalidTitle_ShouldThrowException() {
+        // Given
+        transaction.setType(TransactionType.TRANSFER_INTERNAL);
+        transaction.setAmount(BigDecimal.TEN);
+        transaction.setSourceAccount(sourceAccount);
+        transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Invalid#<>Title!"); // Contains invalid characters
+
+        // When & Then
+        assertThrows(TransactionValidationException.class,
+                () -> validator.validate(transaction),
+                "Transaction title contains invalid characters");
+    }
+
+    @Test
+    void validate_WithValidTitle_ShouldNotThrowException() {
+        // Given
+        transaction.setType(TransactionType.TRANSFER_INTERNAL);
+        transaction.setAmount(BigDecimal.TEN);
+        transaction.setSourceAccount(sourceAccount);
+        transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
+
+        // When & Then
+        assertDoesNotThrow(() -> validator.validate(transaction));
+    }
+
+    @Test
     void validate_TransferWithNullSourceAccount_ShouldThrowException() {
         // Given
         transaction.setType(TransactionType.TRANSFER_INTERNAL);
@@ -112,7 +158,7 @@ class DefaultTransactionValidatorTest {
         transaction.setDestinationAccount(destinationAccount);
 
         // When & Then
-        assertThrows(TransactionValidationException.class, 
+        assertThrows(TransactionValidationException.class,
             () -> validator.validate(transaction),
             "Transfer transaction must have a source account");
     }
@@ -125,7 +171,7 @@ class DefaultTransactionValidatorTest {
         transaction.setSourceAccount(sourceAccount);
 
         // When & Then
-        assertThrows(TransactionValidationException.class, 
+        assertThrows(TransactionValidationException.class,
             () -> validator.validate(transaction),
             "Transfer transaction must have a destination account");
     }
@@ -139,7 +185,7 @@ class DefaultTransactionValidatorTest {
         transaction.setDestinationAccount(sourceAccount);
 
         // When & Then
-        assertThrows(TransactionAccountConflictException.class, 
+        assertThrows(TransactionAccountConflictException.class,
             () -> validator.validate(transaction),
             "Source and destination accounts cannot be the same");
     }
@@ -158,6 +204,7 @@ class DefaultTransactionValidatorTest {
       
         transaction.setSourceAccount(sourceAccount);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When & Then
         assertDoesNotThrow(() -> validator.validate(transaction));
@@ -170,6 +217,7 @@ class DefaultTransactionValidatorTest {
         transaction.setAmount(BigDecimal.TEN);
         transaction.setSourceAccount(sourceAccount);
         transaction.setDestinationAccount(destinationAccount);
+        transaction.setTitle("Valid Title"); // Properly formatted title
 
         // When
         boolean result = validator.isValid(transaction);

--- a/src/test/java/info/mackiewicz/bankapp/integration/BankingOperationsIntegrationTest.java
+++ b/src/test/java/info/mackiewicz/bankapp/integration/BankingOperationsIntegrationTest.java
@@ -431,4 +431,48 @@ public class BankingOperationsIntegrationTest {
         // Checking that the transaction was not saved in the database
         checkTransactionNotSavedInDB();
     }
+
+    @Test
+    @DisplayName("Should return BAD_REQUEST when transaction title with invalid characters")
+    void ibanTransfer_withInvalidTransactionTitle_shouldReturnBadRequest() throws Exception {
+        // Preparing transfer request with invalid title
+        IbanTransferRequest request = new IbanTransferRequest();
+        request.setSourceIban(sourceAccount.getIban());
+        request.setRecipientIban(destinationAccount.getIban());
+        request.setAmount(DEFAULT_TRANSFER_VALUE);
+        request.setTitle("Invalid$Title^<>"); // Invalid characters in title
+
+        // Executing the test
+        mockMvc.perform(post(BANKING_TRANSFER_IBAN_ENDPOINT)
+                        .with(SecurityMockMvcRequestPostProcessors.user(testUser))
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        // Checking that account balances have not changed
+        checkBalancesNotChanged();
+
+        // Checking that the transaction was not saved in the database
+        checkTransactionNotSavedInDB();
+    }
+
+    @Test
+    @DisplayName("Should successfully transfer funds with valid special characters in title")
+    void ibanTransfer_withValidSpecialCharactersInTitle_shouldSucceed() throws Exception {
+        IbanTransferRequest request = new IbanTransferRequest();
+        request.setSourceIban(sourceAccount.getIban());
+        request.setRecipientIban(destinationAccount.getIban());
+        request.setAmount(DEFAULT_TRANSFER_VALUE);
+        request.setTitle("Payment for Order #123 - 50% discount!"); // Valid special chars
+
+        mockMvc.perform(post(BANKING_TRANSFER_IBAN_ENDPOINT)
+                        .with(SecurityMockMvcRequestPostProcessors.user(testUser))
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+
+    }
 }


### PR DESCRIPTION
…t (#84)

* feat(security): validate transaction title format and add related test

- Introduced `TRANSFER_TITLE_PATTERN` in `ValidationConstants` to validate transaction titles.
- Applied a regex pattern to enforce valid title characters in `TransactionRequest`.
- Added integration test to ensure invalid titles return `BAD_REQUEST`.

fixes security issue #83 discovered by @csshark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transaction titles are now validated to allow only specific characters during transfers.
- **Bug Fixes**
  - Transfers with invalid characters in the title are now correctly rejected.
- **Tests**
  - Added integration and unit tests to verify transaction title validation and insufficient funds handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->